### PR TITLE
Refactor/clean up

### DIFF
--- a/Editor/GitOperations/GitOperationsEditorWindow.cs
+++ b/Editor/GitOperations/GitOperationsEditorWindow.cs
@@ -5,7 +5,7 @@
   Copyright:      ©2023-2024 AlchemicalFlux. All rights reserved.
 
   Last commit by: alchemicalflux 
-  Last commit at: 2024-02-15 08:41:19 
+  Last commit at: 2024-11-29 20:48:48 
 ------------------------------------------------------------------------------*/
 using UnityEditor;
 using UnityEngine;
@@ -29,7 +29,7 @@ namespace AlchemicalFlux.Utilities.GitOperations
         private VisualTreeAsset _listViewAsset;
 
         /// <summary>Handle to the editor logic is handled.</summary>
-        private GitOperationsEditor _gitOperationsEditor = new();
+        private readonly GitOperationsEditor _gitOperationsEditor = new();
 
         private GitOperationsEditorUI _gitOperationsEditorUI;
 

--- a/Editor/PackageGeneration/GeneratePackageEditorWindow.cs
+++ b/Editor/PackageGeneration/GeneratePackageEditorWindow.cs
@@ -5,7 +5,7 @@
   Copyright:      ©2023-2024 AlchemicalFlux. All rights reserved.
 
   Last commit by: alchemicalflux 
-  Last commit at: 2024-02-15 08:41:19 
+  Last commit at: 2024-11-29 20:48:48 
 ------------------------------------------------------------------------------*/
 using UnityEditor;
 using UnityEngine;
@@ -25,7 +25,7 @@ namespace AlchemicalFlux.Utilities.PackageGeneration
         private VisualTreeAsset _tree;
 
         /// <summary>Handle to the editor logic is handled.</summary>
-        private GeneratePackageEditor _packageEditor = new();
+        private readonly GeneratePackageEditor _packageEditor = new();
 
         #endregion Members
 

--- a/Shared/GitOperations/GitOperationsEditor.cs
+++ b/Shared/GitOperations/GitOperationsEditor.cs
@@ -5,7 +5,7 @@
   Copyright:      ©2023-2024 AlchemicalFlux. All rights reserved.
 
   Last commit by: alchemicalflux 
-  Last commit at: 2024-02-15 08:41:19 
+  Last commit at: 2024-11-29 20:46:10 
 ------------------------------------------------------------------------------*/
 using AlchemicalFlux.Utilities.Helpers;
 using System;
@@ -34,7 +34,7 @@ namespace AlchemicalFlux.Utilities.GitOperations
 
         public Func<string> GetDirectory;
 
-        private List<FolderData> _directoryList = new List<FolderData>();
+        private List<FolderData> _directoryList = new();
 
         #endregion Members
 
@@ -75,7 +75,7 @@ namespace AlchemicalFlux.Utilities.GitOperations
 
             // Create a list of folder data that will be bound to the UI elements of the list.
             _directoryList = new List<FolderData>();
-            foreach (var directory in gitDirectories)
+            foreach(var directory in gitDirectories)
             {
                 // Trim the folder names to reduce redundancy.
                 var data = ScriptableObject.CreateInstance<FolderData>();
@@ -115,7 +115,7 @@ namespace AlchemicalFlux.Utilities.GitOperations
                 fileOperations.RemoveFilesByName(tempPath, _metaFileExtension);
 
                 // Copy all remaining temp folders to target location.
-                foreach (var folder in preCommitFolders)
+                foreach(var folder in preCommitFolders)
                 {
                     var targetPath = Path.Join(_ui.ParentFolderPath, folder); 
                     targetPath = Path.Join(targetPath, _gitFolderName, GitConstants.PreCommitTargetPath);
@@ -135,7 +135,7 @@ namespace AlchemicalFlux.Utilities.GitOperations
             var semanticReleaseFolders = _directoryList.Where(data => data.IncludeSemanticRelease)
                 .Select(data => data.FolderPath);
 
-            if (semanticReleaseFolders.Any())
+            if(semanticReleaseFolders.Any())
             {
                 var fileOperations = new IOFileSystemService(new RegexStringManipulator());
 
@@ -147,7 +147,7 @@ namespace AlchemicalFlux.Utilities.GitOperations
                 fileOperations.RemoveFilesByName(tempPath, _metaFileExtension);
 
                 // Copy remaining temp folders to the target location.
-                foreach (var folder in semanticReleaseFolders)
+                foreach(var folder in semanticReleaseFolders)
                 {
                     var targetPath = Path.Join(_ui.ParentFolderPath, folder);
                     fileOperations.CopyDirectory(tempPath, targetPath);

--- a/Shared/GitOperations/GitOperationsEditorUI.cs
+++ b/Shared/GitOperations/GitOperationsEditorUI.cs
@@ -5,7 +5,7 @@
   Copyright:      ©2023-2024 AlchemicalFlux. All rights reserved.
 
   Last commit by: alchemicalflux 
-  Last commit at: 2024-02-15 08:41:19 
+  Last commit at: 2024-11-29 20:48:48 
 ------------------------------------------------------------------------------*/
 using AlchemicalFlux.Utilities.Helpers;
 using System;
@@ -22,18 +22,18 @@ namespace AlchemicalFlux.Utilities.GitOperations
         #region Members
 
         /// <summary>UI text entry for the parent folder path.</summary>
-        private TextField _parentFolderTextField;
+        private readonly TextField _parentFolderTextField;
 
         /// <summary>UI button that triggers the parent folder path search functionality.</summary>
-        private Button _folderSearchButton;
+        private readonly Button _folderSearchButton;
 
         /// <summary>UI list view interface for accessing and modifying which folders will be processed.</summary>
-        private ListView _gatheredFoldersList;
+        private readonly ListView _gatheredFoldersList;
 
-        private VisualTreeAsset _listViewTemplate;
+        private readonly VisualTreeAsset _listViewTemplate;
 
         /// <summary></summary>
-        private Button _installButton;
+        private readonly Button _installButton;
 
         /// <summary>Callbacks triggered on the folder search button press.</summary>
         public Action OnSearchPressed;

--- a/Shared/Helpers/FileOperations/IOFileSystemService.cs
+++ b/Shared/Helpers/FileOperations/IOFileSystemService.cs
@@ -5,7 +5,7 @@
   Copyright:      ©2023 AlchemicalFlux. All rights reserved.
 
   Last commit by: alchemicalflux 
-  Last commit at: 2024-11-29 20:46:10 
+  Last commit at: 2024-11-29 21:18:21 
 ------------------------------------------------------------------------------*/
 using System;
 using System.Collections.Generic;
@@ -23,7 +23,7 @@ namespace AlchemicalFlux.Utilities.Helpers
         /// <summary>
         /// Handle to manipulator used to process string replacements.
         /// </summary>
-        private IStringManipulator _stringManipulator;
+        private readonly IStringManipulator _stringManipulator;
 
         #endregion
 
@@ -42,12 +42,7 @@ namespace AlchemicalFlux.Utilities.Helpers
         /// <param name="stringManipulator">Handles all string replacements.</param>
         public IOFileSystemService(IStringManipulator stringManipulator)
         {
-            if(stringManipulator == null)
-            {
-                throw new ArgumentNullException(nameof(stringManipulator));
-            }
-
-            _stringManipulator = stringManipulator;
+            _stringManipulator = stringManipulator ?? throw new ArgumentNullException(nameof(stringManipulator));
         }
 
         #endregion Constructors

--- a/Shared/Helpers/FileOperations/IOFileSystemService.cs
+++ b/Shared/Helpers/FileOperations/IOFileSystemService.cs
@@ -5,7 +5,7 @@
   Copyright:      ©2023 AlchemicalFlux. All rights reserved.
 
   Last commit by: alchemicalflux 
-  Last commit at: 2023-11-01 15:59:50 
+  Last commit at: 2024-11-29 20:46:10 
 ------------------------------------------------------------------------------*/
 using System;
 using System.Collections.Generic;
@@ -72,7 +72,7 @@ namespace AlchemicalFlux.Utilities.Helpers
         public void DeleteDirectory(string targetPath)
         {
             var directoryInfo = new DirectoryInfo(targetPath);
-            if (directoryInfo.Exists)
+            if(directoryInfo.Exists)
             {
                 directoryInfo.Delete(true);
             }
@@ -82,12 +82,12 @@ namespace AlchemicalFlux.Utilities.Helpers
         public void RemoveFoldersByName(string sourcePath, List<string> filters)
         {
             var directoryInfo = new DirectoryInfo(sourcePath);
-            foreach (var filter in filters)
+            foreach(var filter in filters)
             {
                 var directories =
                     directoryInfo.GetDirectories(filter, SearchOption.AllDirectories);
 
-                foreach (var directory in directories)
+                foreach(var directory in directories)
                 {
                     directory.Delete(true);
                 }
@@ -100,7 +100,7 @@ namespace AlchemicalFlux.Utilities.Helpers
             var directoryInfo = new DirectoryInfo(sourcePath);
             var files = directoryInfo.GetFiles(filter, SearchOption.AllDirectories);
 
-            foreach (var file in files)
+            foreach(var file in files)
             {
                 file.Delete();
             }
@@ -113,7 +113,7 @@ namespace AlchemicalFlux.Utilities.Helpers
         {
             var directoryInfo = new DirectoryInfo(sourcePath);
             var files = directoryInfo.GetFiles("*", SearchOption.AllDirectories);
-            foreach (var file in files)
+            foreach(var file in files)
             {
                 // If processFile is provided, use it for additional processing.
                 processFile?.Invoke(file.FullName);
@@ -148,7 +148,7 @@ namespace AlchemicalFlux.Utilities.Helpers
             CreateFolderAndCopyFiles(source, target.FullName);
 
             var directories = source.GetDirectories("*", SearchOption.AllDirectories);
-            foreach (var directory in directories)
+            foreach(var directory in directories)
             {
                 // Calculate the relative path between source and current directory.
                 string relativePath = Path.GetRelativePath(source.FullName, directory.FullName);
@@ -169,7 +169,7 @@ namespace AlchemicalFlux.Utilities.Helpers
         private void CreateFolderAndCopyFiles(DirectoryInfo source, string targetPath)
         {
             Directory.CreateDirectory(targetPath);
-            foreach (var file in source.GetFiles())
+            foreach(var file in source.GetFiles())
             {
                 file.CopyTo(Path.Combine(targetPath, file.Name), true);
             }

--- a/Shared/Helpers/NullCheck/FindNullChecksOnLoad.cs
+++ b/Shared/Helpers/NullCheck/FindNullChecksOnLoad.cs
@@ -8,7 +8,7 @@
   Copyright:      ©2024 AlchemicalFlux. All rights reserved.
 
   Last commit by: alchemicalflux 
-  Last commit at: 2024-11-29 20:46:10 
+  Last commit at: 2024-11-29 21:18:21 
 ------------------------------------------------------------------------------*/
 #if UNITY_EDITOR
 
@@ -63,6 +63,7 @@ namespace AlchemicalFlux.Utilities.Helpers
         /// Checks for null check violations upon exiting edit mode and stops play mode if any are found.
         /// </summary>
         /// <param name="stateChange">The state change event triggered upon exiting edit mode.</param>
+        /*
         private static void CheckOnExitingEditMode(PlayModeStateChange stateChange)
         {
             if(stateChange != PlayModeStateChange.ExitingEditMode) { return; }
@@ -77,6 +78,7 @@ namespace AlchemicalFlux.Utilities.Helpers
                 EditorApplication.isPlaying = false;
             }
         }
+        */
 
         #endregion Methods
     }

--- a/Shared/Helpers/NullCheck/FindNullChecksOnLoad.cs
+++ b/Shared/Helpers/NullCheck/FindNullChecksOnLoad.cs
@@ -8,7 +8,7 @@
   Copyright:      ©2024 AlchemicalFlux. All rights reserved.
 
   Last commit by: alchemicalflux 
-  Last commit at: 2024-02-20 10:30:36 
+  Last commit at: 2024-11-29 20:46:10 
 ------------------------------------------------------------------------------*/
 #if UNITY_EDITOR
 
@@ -32,7 +32,7 @@ namespace AlchemicalFlux.Utilities.Helpers
         /// </summary>
         static FindNullChecksOnLoad()
         {
-            if (!Debug.isDebugBuild) { return; }
+            if(!Debug.isDebugBuild) { return; }
 
             // Schedule a one-time search for null check violations upon the first launch of the editor.
             EditorApplication.update += CheckOnStart;
@@ -53,7 +53,7 @@ namespace AlchemicalFlux.Utilities.Helpers
             foundErrors |= NullCheckProcessing.ProcessGameObjectsInScene();
 
             // If null check violations are found, stop play mode in the editor.
-            if (foundErrors)
+            if(foundErrors)
             {
                 EditorApplication.isPlaying = false;
             }
@@ -72,7 +72,7 @@ namespace AlchemicalFlux.Utilities.Helpers
             foundErrors |= NullCheckProcessing.ProcessGameObjectsInAllScenes();
 
             // If null check violations are found, stop play mode in the editor.
-            if (foundErrors)
+            if(foundErrors)
             {
                 EditorApplication.isPlaying = false;
             }

--- a/Shared/Helpers/NullCheck/NullCheck.cs
+++ b/Shared/Helpers/NullCheck/NullCheck.cs
@@ -5,7 +5,7 @@
   Copyright:      ©2024 AlchemicalFlux. All rights reserved.
 
   Last commit by: alchemicalflux 
-  Last commit at: 2024-02-10 11:12:07 
+  Last commit at: 2024-11-29 20:46:10 
 ------------------------------------------------------------------------------*/
 using System;
 using UnityEngine;
@@ -13,8 +13,7 @@ using UnityEngine;
 namespace AlchemicalFlux.Utilities.Helpers
 {
     /// <summary>
-    /// Indicates that the associated field cannot be left as null within the Unity
-    ///   inspector.
+    /// Indicates that the associated field cannot be left as null within the Unity inspector.
     /// </summary>
     [AttributeUsage(AttributeTargets.Field, Inherited = false, AllowMultiple = false)]
     public class NullCheck : PropertyAttribute 

--- a/Shared/Helpers/NullCheck/NullCheckDrawer.cs
+++ b/Shared/Helpers/NullCheck/NullCheckDrawer.cs
@@ -6,7 +6,7 @@
   Copyright:      ©2024 AlchemicalFlux. All rights reserved.
 
   Last commit by: alchemicalflux 
-  Last commit at: 2024-02-20 10:30:36 
+  Last commit at: 2024-11-29 20:46:10 
 ------------------------------------------------------------------------------*/
 #if UNITY_EDITOR
 
@@ -52,7 +52,7 @@ namespace AlchemicalFlux.Utilities.Helpers
         public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
         {
             var calculatedHeight = base.GetPropertyHeight(property, label); ;
-            if (IsNotObjectRef(property) || ObjectRefNotSet(property))
+            if(IsNotObjectRef(property) || ObjectRefNotSet(property))
             {
                 calculatedHeight += _alertHeight;
             }
@@ -88,19 +88,21 @@ namespace AlchemicalFlux.Utilities.Helpers
         /// <param name="label">Label for the property.</param>
         private void BuildField(Rect drawArea, SerializedProperty property, GUIContent label)
         {
-            if (IsNotObjectRef(property)) // Non-object fields should be rendered normally.
+            var prevColor = GUI.color; // Maintain previous GUI color.
+
+            if(IsNotObjectRef(property)) // Non-object fields should be rendered normally.
             {
                 EditorGUI.PropertyField(drawArea, property, label);
                 return;
             }
 
-            if (ObjectRefNotSet(property)) // Make null references easy to see.
+            if(ObjectRefNotSet(property)) // Make null references easy to see.
             {
                 GUI.color = _alertColor;
-                label.text = "!!! " + label.text;
+                label.text = $"!!! {label.text}";
             }
 
-            if (IsPropertyNotNullInSceneAndPrefab(property))
+            if(IsPropertyNotNullInSceneAndPrefab(property))
             {
                 EditorGUI.BeginDisabledGroup(true);
                 EditorGUI.ObjectField(drawArea, property, label);
@@ -111,7 +113,7 @@ namespace AlchemicalFlux.Utilities.Helpers
                 EditorGUI.ObjectField(drawArea, property, label);
             }
 
-            GUI.color = Color.white; // Reset the GUI color.
+            GUI.color = prevColor; // Reset the GUI color.
         }
 
         /// <summary>
@@ -121,11 +123,11 @@ namespace AlchemicalFlux.Utilities.Helpers
         /// <param name="property">Serialized property.</param>
         private void BuildMessageBox(Rect drawArea, SerializedProperty property)
         {
-            if (IsNotObjectRef(property))
+            if(IsNotObjectRef(property))
             {
                 EditorGUI.HelpBox(drawArea, _warningMessage, MessageType.Warning);
             }
-            else if (ObjectRefNotSet(property))
+            else if(ObjectRefNotSet(property))
             {
                 EditorGUI.HelpBox(drawArea, _errorMessage, MessageType.Error);
             }

--- a/Shared/Helpers/NullCheck/NullCheckFinder.cs
+++ b/Shared/Helpers/NullCheck/NullCheckFinder.cs
@@ -6,7 +6,7 @@
   Copyright:      ©2024 AlchemicalFlux. All rights reserved.
 
   Last commit by: alchemicalflux 
-  Last commit at: 2024-02-20 10:29:21 
+  Last commit at: 2024-11-29 20:46:10 
 ------------------------------------------------------------------------------*/
 using System.Collections.Generic;
 using System.Reflection;
@@ -41,7 +41,7 @@ namespace AlchemicalFlux.Utilities.Helpers
             processing.Push(gameObject);
 
             var errorsOnGameObject = new List<FieldAssociation>();
-            while (processing.Count > 0)
+            while(processing.Count > 0)
             {
                 var obj = processing.Pop();
                 CollectNullCheckViolations(obj);
@@ -62,10 +62,7 @@ namespace AlchemicalFlux.Utilities.Helpers
             // Helper method to add a GameObject's children for processing.
             void AddChildrenForProcessing(GameObject obj)
             {
-                foreach (Transform child in obj.transform)
-                {
-                    processing.Push(child.gameObject);
-                }
+                foreach(Transform child in obj.transform) { processing.Push(child.gameObject); }
             }
 
             #endregion Local Helpers
@@ -77,7 +74,7 @@ namespace AlchemicalFlux.Utilities.Helpers
         private static bool IsPrefab(MonoBehaviour monoBehaviour, FieldInfo fieldInfo, NullCheck att)
         {
             // Value type fields should be processed.
-            if (fieldInfo.FieldType.IsValueType) { return false; }
+            if(fieldInfo.FieldType.IsValueType) { return false; }
 
             var result = false;
 
@@ -97,7 +94,7 @@ namespace AlchemicalFlux.Utilities.Helpers
         /// </summary>
         private static bool NoViolation(FieldInfo fieldInfo, object obj, NullCheck att)
         {
-            // Being attahed to non-object references is considered a violation.
+            // Being attached to non-object references is considered a violation.
             if(fieldInfo.FieldType.IsValueType) { return false; }
 
             // Check that the object reference is not null.

--- a/Shared/Helpers/NullCheck/NullCheckMenuItems.cs
+++ b/Shared/Helpers/NullCheck/NullCheckMenuItems.cs
@@ -8,7 +8,7 @@
   Copyright:      ©2024 AlchemicalFlux. All rights reserved.
 
   Last commit by: alchemicalflux 
-  Last commit at: 2024-02-20 10:30:36 
+  Last commit at: 2024-11-29 20:46:10 
 ------------------------------------------------------------------------------*/
 #if UNITY_EDITOR
 
@@ -78,7 +78,7 @@ namespace AlchemicalFlux.Utilities.Helpers
         /// <param name="errorsFound">Flag indicating whether any errors were found.</param>
         private static void DisplayNoErrorMessage(bool errorsFound)
         {
-            if (!errorsFound)
+            if(!errorsFound)
             {
                 Debug.Log(_noErrorsMessage);
             }

--- a/Shared/Helpers/NullCheck/NullCheckProcessing.cs
+++ b/Shared/Helpers/NullCheck/NullCheckProcessing.cs
@@ -10,7 +10,7 @@
   Copyright:      ©2024 AlchemicalFlux. All rights reserved.
 
   Last commit by: alchemicalflux 
-  Last commit at: 2024-02-20 10:30:36 
+  Last commit at: 2024-11-29 20:46:10 
 ------------------------------------------------------------------------------*/
 #if UNITY_EDITOR
 
@@ -42,12 +42,12 @@ namespace AlchemicalFlux.Utilities.Helpers
         {
             var foundErrors = false;
 
-            if (!EditorSceneManager.SaveCurrentModifiedScenesIfUserWantsTo()) { return false; }
+            if(!EditorSceneManager.SaveCurrentModifiedScenesIfUserWantsTo()) { return false; }
 
             var originalSceneSetup = EditorSceneManager.GetSceneManagerSetup();
 
             var scenePaths = AssetDatabase.FindAssets("t:Scene", new[] { "Assets" });
-            foreach (var scenePath in scenePaths)
+            foreach(var scenePath in scenePaths)
             {
                 string sceneName = AssetDatabase.GUIDToAssetPath(scenePath);
                 EditorSceneManager.OpenScene(sceneName, OpenSceneMode.Single);
@@ -68,9 +68,9 @@ namespace AlchemicalFlux.Utilities.Helpers
         {
             var sceneGameObjects = FindObjectsByType<GameObject>(FindObjectsSortMode.None);
             var foundErrors = false;
-            foreach (var sceneGameObject in sceneGameObjects)
+            foreach(var sceneGameObject in sceneGameObjects)
             {
-                if (sceneGameObject.transform.parent != null) { continue; }
+                if(sceneGameObject.transform.parent != null) { continue; }
 
                 foundErrors |= ProcessErrorsForObject(sceneGameObject, pathToAsset);
             }
@@ -85,11 +85,11 @@ namespace AlchemicalFlux.Utilities.Helpers
         {
             var guidsForAllGameObjects = AssetDatabase.FindAssets("t:GameObject");
             var foundErrors = false;
-            foreach (var guid in guidsForAllGameObjects)
+            foreach(var guid in guidsForAllGameObjects)
             {
                 var pathToGameObject = AssetDatabase.GUIDToAssetPath(guid);
 
-                if (pathToGameObject.Contains(_unitTestLocation)) { continue; }
+                if(pathToGameObject.Contains(_unitTestLocation)) { continue; }
 
                 var gameObject = (GameObject)AssetDatabase.LoadAssetAtPath(pathToGameObject,
                     typeof(GameObject));
@@ -108,7 +108,7 @@ namespace AlchemicalFlux.Utilities.Helpers
         private static bool ProcessErrorsForObject(GameObject gameObject, string pathToAsset)
         {
             var errorsOnGameObject = NullCheckFinder.RetrieveErrors(gameObject);
-            foreach (var violation in errorsOnGameObject)
+            foreach(var violation in errorsOnGameObject)
             {
                 Debug.LogError($"{violation}\nPath: {pathToAsset}", violation.GameObject);
             }

--- a/Shared/Helpers/RefelectionUtilities/AttributeFieldFinder.cs
+++ b/Shared/Helpers/RefelectionUtilities/AttributeFieldFinder.cs
@@ -6,11 +6,12 @@
   Copyright:      ©2024 AlchemicalFlux. All rights reserved.
 
   Last commit by: alchemicalflux 
-  Last commit at: 2024-02-20 10:29:21 
+  Last commit at: 2024-11-29 20:46:10 
 ------------------------------------------------------------------------------*/
 using System;
 using System.Collections.Generic;
 using System.Reflection;
+using System.Threading.Tasks;
 using UnityEngine;
 
 namespace AlchemicalFlux.Utilities.Helpers
@@ -36,15 +37,22 @@ namespace AlchemicalFlux.Utilities.Helpers
             Func<MonoBehaviour, FieldInfo, T, bool> monoBehaviourIgnoreCheck = null,
             Func<FieldInfo, object, T, bool> attributeIgnoreCheck = null) where T : Attribute
         {
-            monoBehaviourIgnoreCheck ??= (_, _, _) => false; // Functor false if the original is null.
+            monoBehaviourIgnoreCheck ??= (_, _, _) => false; // Ensure functor has valid function call.
 
             var fieldAssociations = new List<FieldAssociation>();
             var monobehaviours = obj.GetComponents<MonoBehaviour>();
-            foreach (var monoBehavior in monobehaviours)
+            foreach(var monoBehaviour in monobehaviours)
             {
-                if (monoBehavior == null) { continue; }
-                ProcessMonoBehaviour(monoBehavior);
+                if(monoBehaviour == null) { continue; }
+                ProcessMonoBehaviour(monoBehaviour);
             }
+            /*
+            Parallel.ForEach(monobehaviours, monoBehavior =>
+            {
+                if(monoBehavior == null) { return; }
+                ProcessMonoBehaviour(monoBehavior);
+            });
+            */
             return fieldAssociations;
 
             #region Local Helpers
@@ -54,9 +62,9 @@ namespace AlchemicalFlux.Utilities.Helpers
             {
                 var fields = ReflectionUtility.GetFieldsWithAttribute(monoBehavior,
                     reflectionFlags, attributeIgnoreCheck);
-                foreach (var (field, attribute) in fields)
+                foreach(var (field, attribute) in fields)
                 {
-                    if (monoBehaviourIgnoreCheck(monoBehavior, field, attribute)) { continue; }
+                    if(monoBehaviourIgnoreCheck(monoBehavior, field, attribute)) { continue; }
                     fieldAssociations.Add(new FieldAssociation(field, monoBehavior));
                 }
             }

--- a/Shared/Helpers/RefelectionUtilities/AttributeFieldFinder.cs
+++ b/Shared/Helpers/RefelectionUtilities/AttributeFieldFinder.cs
@@ -6,12 +6,11 @@
   Copyright:      ©2024 AlchemicalFlux. All rights reserved.
 
   Last commit by: alchemicalflux 
-  Last commit at: 2024-11-29 20:46:10 
+  Last commit at: 2024-11-29 21:19:43 
 ------------------------------------------------------------------------------*/
 using System;
 using System.Collections.Generic;
 using System.Reflection;
-using System.Threading.Tasks;
 using UnityEngine;
 
 namespace AlchemicalFlux.Utilities.Helpers

--- a/Shared/Helpers/RefelectionUtilities/ReflectionUtility.cs
+++ b/Shared/Helpers/RefelectionUtilities/ReflectionUtility.cs
@@ -5,7 +5,7 @@
   Copyright:      ©2024 AlchemicalFlux. All rights reserved.
 
   Last commit by: alchemicalflux 
-  Last commit at: 2024-02-20 10:29:21 
+  Last commit at: 2024-11-29 20:46:10 
 ------------------------------------------------------------------------------*/
 using System;
 using System.Collections;
@@ -45,14 +45,14 @@ namespace AlchemicalFlux.Utilities.Helpers
             processing.Push(source);
 
             var fieldsWithAttributes = new List<(FieldInfo field, T attribute)>();
-            while (processing.Count > 0)
+            while(processing.Count > 0)
             {
                 // Process an object, adding it to the outcome if it has the requested attribute.
                 // The attributeIgnoreCheck functor can filter out objects from the final outcome.
                 // If the object is an enumerable container, add its contents to be processed.
                 var obj = processing.Pop();
                 var fields = GetFields(obj.GetType(), reflectionFlags);
-                foreach (var field in fields)
+                foreach(var field in fields)
                 {
                     ProcessField(obj, field);
                 }
@@ -64,7 +64,7 @@ namespace AlchemicalFlux.Utilities.Helpers
             // Helper method to process a field
             void ProcessField(object obj, FieldInfo field)
             {
-                if (enumerable.IsAssignableFrom(field.FieldType))
+                if(enumerable.IsAssignableFrom(field.FieldType))
                 {
                     AddEnumerableChildrenForProcessing(obj, field);
                 }   
@@ -78,7 +78,7 @@ namespace AlchemicalFlux.Utilities.Helpers
             void AddEnumerableChildrenForProcessing(object obj, FieldInfo field)
             {
                 var group = (IEnumerable)field.GetValue(obj);
-                foreach (var iter in group)
+                foreach(var iter in group)
                 {
                     processing.Push(iter);
                 }
@@ -88,7 +88,7 @@ namespace AlchemicalFlux.Utilities.Helpers
             void ProcessNonEnumerableField(object obj, FieldInfo field)
             {
                 var attribute = (T)Attribute.GetCustomAttribute(field, typeOfT);
-                if (attribute == null || attributeIgnoreCheck(field, obj, attribute)) { return; }
+                if(attribute == null || attributeIgnoreCheck(field, obj, attribute)) { return; }
 
                 fieldsWithAttributes.Add((field, attribute));
             }

--- a/Shared/Helpers/StringManipulator/BaseStringManipulator.cs
+++ b/Shared/Helpers/StringManipulator/BaseStringManipulator.cs
@@ -5,7 +5,7 @@
   Copyright:      ©2023 AlchemicalFlux. All rights reserved.
 
   Last commit by: alchemicalflux 
-  Last commit at: 2023-10-24 12:34:07 
+  Last commit at: 2024-11-29 20:46:10 
 ------------------------------------------------------------------------------*/
 using System;
 using System.Collections.Generic;
@@ -33,13 +33,13 @@ namespace AlchemicalFlux.Utilities.Helpers
              string textName, string replacementsName)
         {
             // Handle parameter checks and short circuts.
-            if (text == null || replacements == null)
+            if(text == null || replacements == null)
             {
                 var paramName = (text == null) ? textName : string.Empty;
                 paramName += (paramName != string.Empty && replacements == null) ? " and " : string.Empty;
                 paramName += (replacements == null) ? replacementsName : string.Empty;
 
-                var message = "The '" + paramName + "' parameter(s) cannot be null.";
+                var message = $"The '{paramName}' parameter(s) cannot be null.";
 
                 throw new ArgumentNullException(paramName, message);
             }

--- a/Shared/Helpers/StringManipulator/BasicStringManipulator.cs
+++ b/Shared/Helpers/StringManipulator/BasicStringManipulator.cs
@@ -5,7 +5,7 @@
   Copyright:      ©2023 AlchemicalFlux. All rights reserved.
 
   Last commit by: alchemicalflux 
-  Last commit at: 2023-10-24 12:34:07 
+  Last commit at: 2024-11-29 20:46:10 
 ------------------------------------------------------------------------------*/
 using System.Collections.Generic;
 using System.Linq;
@@ -25,7 +25,7 @@ namespace AlchemicalFlux.Utilities.Helpers
         /// </remarks>   
         public override string MultipleReplace(string originalText, Dictionary<string, string> replacements)
         {
-            if (AreParametersInvalid(originalText, replacements, nameof(originalText), nameof(replacements)))
+            if(AreParametersInvalid(originalText, replacements, nameof(originalText), nameof(replacements)))
             {
                 return originalText;
             }
@@ -38,17 +38,17 @@ namespace AlchemicalFlux.Utilities.Helpers
             // Concatenates all keys to a searchable pattern.
             // Upon finding an entry to replace, it attempts to match with key / value in the replacements.
             return Regex.Replace(originalText,
-                "(" + string.Join("|", escapedKeys) + ")",
+                $"({string.Join("|", escapedKeys)})",
                 delegate (Match m)
                 {
-                // Use TryGetValue to avoid KeyNotFoundException
-                if (replacements.TryGetValue(m.Value, out string replacement))
-                    {
-                        return replacement;
-                    }
+                    // Use TryGetValue to avoid KeyNotFoundException
+                    if(replacements.TryGetValue(m.Value, out string replacement))
+                        {
+                            return replacement;
+                        }
 
-                // If the key is not found, return the original value (without replacement).
-                return m.Value;
+                    // If the key is not found, return the original value (without replacement).
+                    return m.Value;
                 }
             );
         }

--- a/Shared/Helpers/StringManipulator/RegexStringManipulator.cs
+++ b/Shared/Helpers/StringManipulator/RegexStringManipulator.cs
@@ -5,7 +5,7 @@
   Copyright:      ©2023 AlchemicalFlux. All rights reserved.
 
   Last commit by: alchemicalflux 
-  Last commit at: 2023-10-24 12:34:07 
+  Last commit at: 2024-11-29 20:46:10 
 ------------------------------------------------------------------------------*/
 using System.Collections.Generic;
 using System.Linq;
@@ -25,7 +25,7 @@ namespace AlchemicalFlux.Utilities.Helpers
         /// </remarks>
         public override string MultipleReplace(string originalText, Dictionary<string, string> replacements)
         {
-            if (AreParametersInvalid(originalText, replacements, nameof(originalText), nameof(replacements)))
+            if(AreParametersInvalid(originalText, replacements, nameof(originalText), nameof(replacements)))
             {
                 return originalText;
             }
@@ -34,7 +34,7 @@ namespace AlchemicalFlux.Utilities.Helpers
             var orderedList = replacements.Select(m => m.Key)
                 .OrderByDescending(key => key.Length)
                 .ThenBy(key => key);
-            var pattern = "(" + string.Join("|", orderedList) + ")";
+            var pattern = $"({string.Join("|", orderedList)})";
 
             // Concatenates all keys to a searchable pattern.
             // Upon finding an entry to replace, it matches it with all keys that qualify,

--- a/Shared/PackageGeneration/PackageEditorUI.cs
+++ b/Shared/PackageGeneration/PackageEditorUI.cs
@@ -5,7 +5,7 @@
   Copyright:      ©2023 AlchemicalFlux. All rights reserved.
 
   Last commit by: alchemicalflux 
-  Last commit at: 2024-11-29 20:46:10 
+  Last commit at: 2024-11-29 21:18:21 
 ------------------------------------------------------------------------------*/
 using AlchemicalFlux.Utilities.Helpers;
 using System;
@@ -23,31 +23,31 @@ namespace AlchemicalFlux.Utilities.PackageGeneration
         #region Members
 
         /// <summary>UI text entry for package display name in Package folder.</summary>
-        private TextField _displayField;
+        private readonly TextField _displayField;
         /// <summary>UI text entry for domain portion of package name.</summary>
-        private TextField _domainField;
+        private readonly TextField _domainField;
         /// <summary>UI text entry for company portion of package name.</summary>
-        private TextField _companyField;
+        private readonly TextField _companyField;
         /// <summary>UI text entry for project portion of package name.</summary>
-        private TextField _projectField;
+        private readonly TextField _projectField;
         /// <summary>UI text entry for company portion of folder and file names.</summary>
-        private TextField _companyNamespace;
+        private readonly TextField _companyNamespace;
         /// <summary>UI text entry for project portion of folder and file names.</summary>
-        private TextField _projectNamespace;
+        private readonly TextField _projectNamespace;
 
         /// <summary>UI flag for creating runtime related folders/files.</summary>
-        private Toggle _setupRuntimeToggle;
+        private readonly Toggle _setupRuntimeToggle;
         /// <summary>UI flag for creating editor related folders/files.</summary>
-        private Toggle _setupEditorToggle;
+        private readonly Toggle _setupEditorToggle;
         /// <summary>UI flag indicating if test structures should be included.</summary>
-        private Toggle _includeTestsToggle;
+        private readonly Toggle _includeTestsToggle;
         /// <summary>UI flag indicating if documentation structures should be included.</summary>
-        private Toggle _documentationToggle;
+        private readonly Toggle _documentationToggle;
         /// <summary>UI flag indicating if sample structures should be included.</summary>
-        private Toggle _includeSamplesToggle;
+        private readonly Toggle _includeSamplesToggle;
 
         /// <summary>UI button that triggers save feature.</summary>
-        private Button _saveButton;
+        private readonly Button _saveButton;
 
         /// <summary>Callbacks triggered on save button press.</summary>
         public Action OnSavePressed;

--- a/Shared/PackageGeneration/PackageEditorUI.cs
+++ b/Shared/PackageGeneration/PackageEditorUI.cs
@@ -5,7 +5,7 @@
   Copyright:      ©2023 AlchemicalFlux. All rights reserved.
 
   Last commit by: alchemicalflux 
-  Last commit at: 2024-02-15 08:41:19 
+  Last commit at: 2024-11-29 20:46:10 
 ------------------------------------------------------------------------------*/
 using AlchemicalFlux.Utilities.Helpers;
 using System;
@@ -65,8 +65,8 @@ namespace AlchemicalFlux.Utilities.PackageGeneration
         /// The deletion status of various folders.
         /// </summary>
         public Dictionary<string, bool> FolderConditions => new() {
-            { PackageConstants.TestsFolderName, _includeTestsToggle.value},
-            { PackageConstants.RuntimeFolderName, _setupRuntimeToggle.value},
+            { PackageConstants.TestsFolderName, _includeTestsToggle.value },
+            { PackageConstants.RuntimeFolderName, _setupRuntimeToggle.value },
             { PackageConstants.EditorFolderName, _setupEditorToggle.value },
             { PackageConstants.DocumentationFolderName, _documentationToggle.value },
             { PackageConstants.SamplesFolderName, _includeSamplesToggle.value },
@@ -77,7 +77,7 @@ namespace AlchemicalFlux.Utilities.PackageGeneration
         /// </summary>
         public List<string> FoldersToRemove => FolderConditions
             .Where(folderCondition => !folderCondition.Value)
-            .Select(folderCondition => "*" + folderCondition.Key + "*")
+            .Select(folderCondition => $"*{folderCondition.Key}*")
             .ToList();
 
         /// <summary>

--- a/Tests/Editor/Scripts/Helpers/Extensions/DictionaryExtensionsTests.cs
+++ b/Tests/Editor/Scripts/Helpers/Extensions/DictionaryExtensionsTests.cs
@@ -5,7 +5,7 @@
   Copyright:      ©2023 AlchemicalFlux. All rights reserved.
 
   Last commit by: alchemicalflux 
-  Last commit at: 2024-11-29 20:48:48 
+  Last commit at: 2024-11-29 20:56:00 
 ------------------------------------------------------------------------------*/
 using NUnit.Framework;
 using System.Collections.Generic;
@@ -88,11 +88,11 @@ namespace AlchemicalFlux.Utilities.Helpers.Tests
         {
             {
                 _selfIsNullTestName,
-                new TestCaseData(null, new Dictionary<string, int>())
+                new(null, new Dictionary<string, int>())
             },
             {
                 _otherIsNullTestName,
-                new TestCaseData(new Dictionary<string, int>(), null)
+                new(new Dictionary<string, int>(), null)
             },
         };
 
@@ -107,23 +107,23 @@ namespace AlchemicalFlux.Utilities.Helpers.Tests
         {
             {
                 _selfIsEmptyTestName,
-                new TestCaseData(new Dictionary<string, int>(), _oneElement, _oneElement)
+                new(new Dictionary<string, int>(), _oneElement, _oneElement)
             },
             {
                 _otherIsEmptyTestName,
-                new TestCaseData(_oneElement, new Dictionary<string, int>(), _oneElement)
+                new(_oneElement, new Dictionary<string, int>(), _oneElement)
             },
             {
                 _noConflictKeysTestName,
-                new TestCaseData(_noConflictA, _noConflictB, _noConflictResult)
+                new(_noConflictA, _noConflictB, _noConflictResult)
             },
             {
                 _dictionariesWithConflictKeysTestName,
-                new TestCaseData(_conflictA, _conflictB, _conflictResult)
+                new(_conflictA, _conflictB, _conflictResult)
             },
             {
                 _reverseDictionaryOrderTestName,
-                new TestCaseData(_conflictB, _conflictA, _conflictReversedResult)
+                new(_conflictB, _conflictA, _conflictReversedResult)
             },
         };
 

--- a/Tests/Editor/Scripts/Helpers/Extensions/DictionaryExtensionsTests.cs
+++ b/Tests/Editor/Scripts/Helpers/Extensions/DictionaryExtensionsTests.cs
@@ -5,7 +5,7 @@
   Copyright:      ©2023 AlchemicalFlux. All rights reserved.
 
   Last commit by: alchemicalflux 
-  Last commit at: 2024-02-15 08:41:19 
+  Last commit at: 2024-11-29 20:48:48 
 ------------------------------------------------------------------------------*/
 using NUnit.Framework;
 using System.Collections.Generic;
@@ -22,27 +22,25 @@ namespace AlchemicalFlux.Utilities.Helpers.Tests
         #region Test Values
 
         // Simple value
-
-        private static Dictionary<string, int> _oneElement =
-            new Dictionary<string, int>()
-            {
-                { "A", 1 },
-            };
+        private static readonly Dictionary<string, int> _oneElement = new()
+        {
+            { "A", 1 },
+        };
 
         // No Conflict values
-        private static Dictionary<string, int> _noConflictA = new Dictionary<string, int>()
+        private static readonly Dictionary<string, int> _noConflictA = new()
         {
             { "A1", 1 },
             { "A2", 2 },
         };
 
-        private static Dictionary<string, int> _noConflictB = new Dictionary<string, int>()
+        private static readonly Dictionary<string, int> _noConflictB = new()
         {
             { "B1", 1 },
             { "B2", 2 },
         };
 
-        private static Dictionary<string, int> _noConflictResult = new Dictionary<string, int>()
+        private static readonly Dictionary<string, int> _noConflictResult = new()
         {
             { "A1", 1 },
             { "A2", 2 },
@@ -51,26 +49,26 @@ namespace AlchemicalFlux.Utilities.Helpers.Tests
         };
 
         // Conflict values
-        private static Dictionary<string, int> _conflictA = new Dictionary<string, int>()
+        private static readonly Dictionary<string, int> _conflictA = new()
         {
             { "A", 1 },
             { "B", 1 },
         };
 
-        private static readonly Dictionary<string, int> _conflictB = new Dictionary<string, int>()
+        private static readonly Dictionary<string, int> _conflictB = new()
         {
             { "B", 2 },
             { "C", 1 },
         };
 
-        private static readonly Dictionary<string, int> _conflictResult = new Dictionary<string, int>()
+        private static readonly Dictionary<string, int> _conflictResult = new()
         {
             { "A", 1 },
             { "B", 1 },
             { "C", 1 },
         };
 
-        private static readonly Dictionary<string, int> _conflictReversedResult = new Dictionary<string, int>()
+        private static readonly Dictionary<string, int> _conflictReversedResult = new()
         {
             { "A", 1 },
             { "B", 2 },
@@ -86,18 +84,17 @@ namespace AlchemicalFlux.Utilities.Helpers.Tests
         private const string _selfIsNullTestName = "SelfIsNull_ThrowArgumentNullException";
         private const string _otherIsNullTestName = "OtherIsNull_ThrowArgumentNullException";
 
-        private static readonly Dictionary<string, TestCaseData> _invalidScenariosData =
-            new Dictionary<string, TestCaseData>()
+        private static readonly Dictionary<string, TestCaseData> _invalidScenariosData = new()
+        {
             {
-                {
-                    _selfIsNullTestName,
-                    new TestCaseData(null, new Dictionary<string, int>())
-                },
-                {
-                    _otherIsNullTestName,
-                    new TestCaseData(new Dictionary<string, int>(), null)
-                },
-            };
+                _selfIsNullTestName,
+                new TestCaseData(null, new Dictionary<string, int>())
+            },
+            {
+                _otherIsNullTestName,
+                new TestCaseData(new Dictionary<string, int>(), null)
+            },
+        };
 
         // Merging Scenario Tests
         private const string _selfIsEmptyTestName = "SelfIsEmpty_ResultMatchesOther";
@@ -106,30 +103,29 @@ namespace AlchemicalFlux.Utilities.Helpers.Tests
         private const string _dictionariesWithConflictKeysTestName = "DictionariesWithConflictKeys_ResultContainsSelfKeys";
         private const string _reverseDictionaryOrderTestName = "ReverseDictionaryOrder_ConflictKeyHasDifferentValue";
 
-        private static readonly Dictionary<string, TestCaseData> _mergingScenariosData =
-            new Dictionary<string, TestCaseData>()
+        private static readonly Dictionary<string, TestCaseData> _mergingScenariosData = new()
+        {
             {
-                {
-                    _selfIsEmptyTestName,
-                    new TestCaseData(new Dictionary<string, int>(), _oneElement, _oneElement)
-                },
-                {
-                    _otherIsEmptyTestName,
-                    new TestCaseData(_oneElement, new Dictionary<string, int>(), _oneElement)
-                },
-                {
-                    _noConflictKeysTestName,
-                    new TestCaseData(_noConflictA, _noConflictB, _noConflictResult)
-                },
-                {
-                    _dictionariesWithConflictKeysTestName,
-                    new TestCaseData(_conflictA, _conflictB, _conflictResult)
-                },
-                {
-                    _reverseDictionaryOrderTestName,
-                    new TestCaseData(_conflictB, _conflictA, _conflictReversedResult)
-                },
-            };
+                _selfIsEmptyTestName,
+                new TestCaseData(new Dictionary<string, int>(), _oneElement, _oneElement)
+            },
+            {
+                _otherIsEmptyTestName,
+                new TestCaseData(_oneElement, new Dictionary<string, int>(), _oneElement)
+            },
+            {
+                _noConflictKeysTestName,
+                new TestCaseData(_noConflictA, _noConflictB, _noConflictResult)
+            },
+            {
+                _dictionariesWithConflictKeysTestName,
+                new TestCaseData(_conflictA, _conflictB, _conflictResult)
+            },
+            {
+                _reverseDictionaryOrderTestName,
+                new TestCaseData(_conflictB, _conflictA, _conflictReversedResult)
+            },
+        };
 
         #endregion Test Scenarios
 
@@ -141,7 +137,7 @@ namespace AlchemicalFlux.Utilities.Helpers.Tests
 
         private static IEnumerable<TestCaseData> InvalidParameterScenarios()
         {
-            foreach (var scenario in _invalidScenariosData)
+            foreach(var scenario in _invalidScenariosData)
             {
                 yield return scenario.Value.SetName(scenario.Key);
             }
@@ -149,7 +145,7 @@ namespace AlchemicalFlux.Utilities.Helpers.Tests
 
         private static IEnumerable<TestCaseData> MergingScenarios()
         {
-            foreach (var scenario in _mergingScenariosData)
+            foreach(var scenario in _mergingScenariosData)
             {
                 yield return scenario.Value.SetName(scenario.Key);
             }
@@ -164,7 +160,7 @@ namespace AlchemicalFlux.Utilities.Helpers.Tests
         public void Merge_InvalidParameterTests(Dictionary<string, int> self,
             Dictionary<string, int> other)
         {
-            // Assert
+            // Act and Assert - Functor must be called due to expected exception throw check.
             Assert.That(() => self.Merge(other), Throws.ArgumentNullException);
         }
 

--- a/Tests/Editor/Scripts/Helpers/StringManipulator/IStringManipulatorTests.cs
+++ b/Tests/Editor/Scripts/Helpers/StringManipulator/IStringManipulatorTests.cs
@@ -5,7 +5,7 @@
   Copyright:      ©2023 AlchemicalFlux. All rights reserved.
 
   Last commit by: alchemicalflux 
-  Last commit at: 2024-02-15 08:41:19 
+  Last commit at: 2024-11-29 20:46:10 
 ------------------------------------------------------------------------------*/
 using NUnit.Framework;
 using System.Collections.Generic;
@@ -170,7 +170,7 @@ namespace AlchemicalFlux.Utilities.Helpers.Tests
 
         public static IEnumerable<TestCaseData> InvalidScenarios()
         {
-            foreach (var scenario in InvalidScenariosData)
+            foreach(var scenario in InvalidScenariosData)
             {
                 yield return scenario.Value.SetName(scenario.Key);
             }
@@ -178,7 +178,7 @@ namespace AlchemicalFlux.Utilities.Helpers.Tests
 
         public static IEnumerable<TestCaseData> ReplacementScenarios()
         {
-            foreach (var scenario in ReplacementScenariosData)
+            foreach(var scenario in ReplacementScenariosData)
             {
                 yield return scenario.Value.SetName(scenario.Key);
             }

--- a/Tests/Editor/Scripts/Helpers/StringManipulator/IStringManipulatorTests.cs
+++ b/Tests/Editor/Scripts/Helpers/StringManipulator/IStringManipulatorTests.cs
@@ -5,7 +5,7 @@
   Copyright:      ©2023 AlchemicalFlux. All rights reserved.
 
   Last commit by: alchemicalflux 
-  Last commit at: 2024-11-29 20:56:00 
+  Last commit at: 2024-11-29 21:18:21 
 ------------------------------------------------------------------------------*/
 using NUnit.Framework;
 using System.Collections.Generic;
@@ -28,14 +28,13 @@ namespace AlchemicalFlux.Utilities.Helpers.Tests
 
         // Standard Replacement values
         protected const string StandardText = "Hello {FirstName}, you are from {Country}.";
-        protected static readonly Dictionary<string, string> StandardReplacements = 
-            new Dictionary<string, string>()
-            {
-                { "{FirstName}", "John" },
-                { "{Country}", "USA" },
-                { "Garbage", "Should Not Replace" },
-                { "fasdf", null },
-            };
+        protected static readonly Dictionary<string, string> StandardReplacements = new()
+        {
+            { "{FirstName}", "John" },
+            { "{Country}", "USA" },
+            { "Garbage", "Should Not Replace" },
+            { "fasdf", null },
+        };
         protected const string StandardResult = "Hello John, you are from USA.";
 
         // Case Sensitivty
@@ -47,39 +46,36 @@ namespace AlchemicalFlux.Utilities.Helpers.Tests
 
         // Longest Key First values
         protected const string LongestKeyFirstText = "The quick brown fox jumps over the lazy dog.";
-        protected static readonly Dictionary<string, string> LongestKeyFirstReplacements = 
-            new Dictionary<string, string>()
-            {
-                { "the lazy", "the energetic" },
-                { "the lazy ", "the scared " },
+        protected static readonly Dictionary<string, string> LongestKeyFirstReplacements = new()
+        {
+            { "the lazy", "the energetic" },
+            { "the lazy ", "the scared " },
 
-                { "fox jumps", "cat leaps"},
-                { "fox jumps over", "squirrel scampers above"},
-                { "jumps over", "hops across"},
-            };
+            { "fox jumps", "cat leaps"},
+            { "fox jumps over", "squirrel scampers above"},
+            { "jumps over", "hops across"},
+        };
         protected const string LongestKeyFirstResult = "The quick brown squirrel scampers above the scared dog.";
 
         // Escape Characters
         protected const string EscapeCharactersText = "Replace newline: \\n, tab: \\t, and backslash: \\\\";
-        protected static readonly Dictionary<string, string> EscapeCharactersReplacements = 
-            new Dictionary<string, string>()
-            {
-                { "\\n", "\n" },
-                { "\\t", "\t" },
-                { "\\\\", "\\" },
-            };
+        protected static readonly Dictionary<string, string> EscapeCharactersReplacements = new()
+        {
+            { "\\n", "\n" },
+            { "\\t", "\t" },
+            { "\\\\", "\\" },
+        };
         protected const string EscapeCharactersResult = "Replace newline: \n, tab: \t, and backslash: \\";
 
         // Special Characters
         protected const string SpecialCharactersText = "Replace ( { and } ) with special characters";
-        protected static readonly Dictionary<string, string> SpecialCharactersReplacements =
-            new Dictionary<string, string>
-            {
-                { "(", "[1]" },
-                { ")", "[2]" },
-                { "{", "[3]" },
-                { "}", "[4]" },
-            };
+        protected static readonly Dictionary<string, string> SpecialCharactersReplacements = new()
+        {
+            { "(", "[1]" },
+            { ")", "[2]" },
+            { "{", "[3]" },
+            { "}", "[4]" },
+        };
         protected const string SpecialCharactersResult = "Replace [1] [3] and [4] [2] with special characters";
 
         #endregion Test Values
@@ -91,18 +87,17 @@ namespace AlchemicalFlux.Utilities.Helpers.Tests
         protected const string InitialTextNullTestName = "InitialTextIsNull_ThrowArguementNullException";
         protected const string ReplacementsIsNullTestName = "ReplacementsIsNull_ThrowArguementNullException";
 
-        protected static readonly Dictionary<string, TestCaseData> InvalidScenariosData =
-            new Dictionary<string, TestCaseData>()
+        protected static readonly Dictionary<string, TestCaseData> InvalidScenariosData = new()
+        {
             {
-                {
-                    InitialTextNullTestName,
-                    new(new TStringManipulator(), null, StandardReplacements)
-                },
-                {
-                    ReplacementsIsNullTestName,
-                    new(new TStringManipulator(), DefaultText, null)
-                }
-            };
+                InitialTextNullTestName,
+                new(new TStringManipulator(), null, StandardReplacements)
+            },
+            {
+                ReplacementsIsNullTestName,
+                new(new TStringManipulator(), DefaultText, null)
+            }
+        };
 
         // Replacement Scenario Tests
 
@@ -115,50 +110,49 @@ namespace AlchemicalFlux.Utilities.Helpers.Tests
         protected const string EscapeCharacterReplacementTestName = "EscapeCharacterReplacements_ReturnModifiedString";
         protected const string SpecialCharacterReplacementsTestName = "SpecialCharacterReplacements_ReturnModifiedString";
 
-        protected static readonly Dictionary<string, TestCaseData> ReplacementScenariosData =
-            new Dictionary<string, TestCaseData>()
+        protected static readonly Dictionary<string, TestCaseData> ReplacementScenariosData = new()
+        {
             {
-                {
-                    EmptyInitialStringTestName,
-                    new(new TStringManipulator(), 
-                        string.Empty, StandardReplacements, string.Empty)
-                },
-                {
-                    EmptyReplacementsTestName,
-                    new(new TStringManipulator(), 
-                        DefaultText, new Dictionary<string, string>(), DefaultText)
-                },
-                {
-                    SimpleReplacementsTestName,
-                    new(new TStringManipulator(), 
-                        StandardText, StandardReplacements, StandardResult)
-                },
-                {
-                    LowerCaseSensitivityTestName,
-                    new(new TStringManipulator(),
-                        LowerCaseText, StandardReplacements, LowerCaseResult)
-                },
-                {
-                    UpperCaseSensitivityTestName,
-                    new(new TStringManipulator(), 
-                        UpperCaseText, StandardReplacements, UpperCaseResult)
-                },
-                {
-                    OverlappingReplacementsTestName,
-                    new(new TStringManipulator(), 
-                        LongestKeyFirstText, LongestKeyFirstReplacements, LongestKeyFirstResult)
-                },
-                {
-                    EscapeCharacterReplacementTestName,
-                    new(new TStringManipulator(), 
-                        EscapeCharactersText, EscapeCharactersReplacements, EscapeCharactersResult)
-                },
-                {
-                    SpecialCharacterReplacementsTestName,
-                    new(new TStringManipulator(), 
-                        SpecialCharactersText, SpecialCharactersReplacements, SpecialCharactersResult)
-                },
-            };
+                EmptyInitialStringTestName,
+                new(new TStringManipulator(), 
+                    string.Empty, StandardReplacements, string.Empty)
+            },
+            {
+                EmptyReplacementsTestName,
+                new(new TStringManipulator(), 
+                    DefaultText, new Dictionary<string, string>(), DefaultText)
+            },
+            {
+                SimpleReplacementsTestName,
+                new(new TStringManipulator(), 
+                    StandardText, StandardReplacements, StandardResult)
+            },
+            {
+                LowerCaseSensitivityTestName,
+                new(new TStringManipulator(),
+                    LowerCaseText, StandardReplacements, LowerCaseResult)
+            },
+            {
+                UpperCaseSensitivityTestName,
+                new(new TStringManipulator(), 
+                    UpperCaseText, StandardReplacements, UpperCaseResult)
+            },
+            {
+                OverlappingReplacementsTestName,
+                new(new TStringManipulator(), 
+                    LongestKeyFirstText, LongestKeyFirstReplacements, LongestKeyFirstResult)
+            },
+            {
+                EscapeCharacterReplacementTestName,
+                new(new TStringManipulator(), 
+                    EscapeCharactersText, EscapeCharactersReplacements, EscapeCharactersResult)
+            },
+            {
+                SpecialCharacterReplacementsTestName,
+                new(new TStringManipulator(), 
+                    SpecialCharactersText, SpecialCharactersReplacements, SpecialCharactersResult)
+            },
+        };
 
         #endregion Test Scenarios
 

--- a/Tests/Editor/Scripts/Helpers/StringManipulator/IStringManipulatorTests.cs
+++ b/Tests/Editor/Scripts/Helpers/StringManipulator/IStringManipulatorTests.cs
@@ -5,7 +5,7 @@
   Copyright:      ©2023 AlchemicalFlux. All rights reserved.
 
   Last commit by: alchemicalflux 
-  Last commit at: 2024-11-29 20:46:10 
+  Last commit at: 2024-11-29 20:56:00 
 ------------------------------------------------------------------------------*/
 using NUnit.Framework;
 using System.Collections.Generic;
@@ -96,11 +96,11 @@ namespace AlchemicalFlux.Utilities.Helpers.Tests
             {
                 {
                     InitialTextNullTestName,
-                    new TestCaseData(new TStringManipulator(), null, StandardReplacements)
+                    new(new TStringManipulator(), null, StandardReplacements)
                 },
                 {
                     ReplacementsIsNullTestName,
-                    new TestCaseData(new TStringManipulator(), DefaultText, null)
+                    new(new TStringManipulator(), DefaultText, null)
                 }
             };
 
@@ -120,42 +120,42 @@ namespace AlchemicalFlux.Utilities.Helpers.Tests
             {
                 {
                     EmptyInitialStringTestName,
-                    new TestCaseData(new TStringManipulator(), 
+                    new(new TStringManipulator(), 
                         string.Empty, StandardReplacements, string.Empty)
                 },
                 {
                     EmptyReplacementsTestName,
-                    new TestCaseData(new TStringManipulator(), 
+                    new(new TStringManipulator(), 
                         DefaultText, new Dictionary<string, string>(), DefaultText)
                 },
                 {
                     SimpleReplacementsTestName,
-                    new TestCaseData(new TStringManipulator(), 
+                    new(new TStringManipulator(), 
                         StandardText, StandardReplacements, StandardResult)
                 },
                 {
                     LowerCaseSensitivityTestName,
-                    new TestCaseData(new TStringManipulator(),
+                    new(new TStringManipulator(),
                         LowerCaseText, StandardReplacements, LowerCaseResult)
                 },
                 {
                     UpperCaseSensitivityTestName,
-                    new TestCaseData(new TStringManipulator(), 
+                    new(new TStringManipulator(), 
                         UpperCaseText, StandardReplacements, UpperCaseResult)
                 },
                 {
                     OverlappingReplacementsTestName,
-                    new TestCaseData(new TStringManipulator(), 
+                    new(new TStringManipulator(), 
                         LongestKeyFirstText, LongestKeyFirstReplacements, LongestKeyFirstResult)
                 },
                 {
                     EscapeCharacterReplacementTestName,
-                    new TestCaseData(new TStringManipulator(), 
+                    new(new TStringManipulator(), 
                         EscapeCharactersText, EscapeCharactersReplacements, EscapeCharactersResult)
                 },
                 {
                     SpecialCharacterReplacementsTestName,
-                    new TestCaseData(new TStringManipulator(), 
+                    new(new TStringManipulator(), 
                         SpecialCharactersText, SpecialCharactersReplacements, SpecialCharactersResult)
                 },
             };

--- a/Tests/Editor/Scripts/Helpers/StringManipulator/RegexStringManipulatorTests.cs
+++ b/Tests/Editor/Scripts/Helpers/StringManipulator/RegexStringManipulatorTests.cs
@@ -5,7 +5,7 @@
   Copyright:      ©2023 AlchemicalFlux. All rights reserved.
 
   Last commit by: alchemicalflux 
-  Last commit at: 2024-02-15 08:41:19 
+  Last commit at: 2024-11-29 20:46:10 
 ------------------------------------------------------------------------------*/
 using NUnit.Framework;
 using System.Collections.Generic;
@@ -90,7 +90,7 @@ namespace AlchemicalFlux.Utilities.Helpers.Tests
         public static IEnumerable<TestCaseData> RegexReplacementScenarios()
         {
             var merged = RegexReplacementScenariosData.Merge(ReplacementScenariosData);
-            foreach (var scenario in merged)
+            foreach(var scenario in merged)
             {
                 yield return scenario.Value.SetName(scenario.Key);
             }

--- a/Tests/Editor/Scripts/Helpers/StringManipulator/RegexStringManipulatorTests.cs
+++ b/Tests/Editor/Scripts/Helpers/StringManipulator/RegexStringManipulatorTests.cs
@@ -5,7 +5,7 @@
   Copyright:      ©2023 AlchemicalFlux. All rights reserved.
 
   Last commit by: alchemicalflux 
-  Last commit at: 2024-11-29 20:46:10 
+  Last commit at: 2024-11-29 20:56:00 
 ------------------------------------------------------------------------------*/
 using NUnit.Framework;
 using System.Collections.Generic;
@@ -64,17 +64,17 @@ namespace AlchemicalFlux.Utilities.Helpers.Tests
             {
                 {
                     EscapeCharacterReplacementTestName,
-                    new TestCaseData(new RegexStringManipulator(),
+                    new(new RegexStringManipulator(),
                         EscapeCharactersText, RegexCharactersReplacements, EscapeCharactersResult)
                 },
                 {
                     SpecialCharacterReplacementsTestName,
-                    new TestCaseData(new RegexStringManipulator(),
+                    new(new RegexStringManipulator(),
                         SpecialCharactersText, RegexSpecialCharactersReplacements, SpecialCharactersResult)
                 },
                 {
                     RegexReplacementsTestName,
-                    new TestCaseData(new RegexStringManipulator(),
+                    new(new RegexStringManipulator(),
                         RegexText, RegexReplacements, RegexResults)
                 },
             };

--- a/Tests/Editor/Scripts/Helpers/StringManipulator/RegexStringManipulatorTests.cs
+++ b/Tests/Editor/Scripts/Helpers/StringManipulator/RegexStringManipulatorTests.cs
@@ -5,7 +5,7 @@
   Copyright:      ©2023 AlchemicalFlux. All rights reserved.
 
   Last commit by: alchemicalflux 
-  Last commit at: 2024-11-29 20:56:00 
+  Last commit at: 2024-11-29 21:18:21 
 ------------------------------------------------------------------------------*/
 using NUnit.Framework;
 using System.Collections.Generic;
@@ -25,31 +25,28 @@ namespace AlchemicalFlux.Utilities.Helpers.Tests
         #region Test Values
 
         // Escape Characters
-        protected static readonly Dictionary<string, string> RegexCharactersReplacements = 
-            new Dictionary<string, string>()
-            {
-                { Regex.Escape("\\n"), "\n" },
-                { Regex.Escape("\\t"), "\t" },
-                { Regex.Escape("\\\\"), "\\" },
-            };
+        protected static readonly Dictionary<string, string> RegexCharactersReplacements = new()
+        {
+            { Regex.Escape("\\n"), "\n" },
+            { Regex.Escape("\\t"), "\t" },
+            { Regex.Escape("\\\\"), "\\" },
+        };
 
         // Special Characters
-        protected static readonly Dictionary<string, string> RegexSpecialCharactersReplacements = 
-            new Dictionary<string, string>
-            {
-                { Regex.Escape("("), "[1]" },
-                { Regex.Escape(")"), "[2]" },
-                { Regex.Escape("{"), "[3]" },
-                { Regex.Escape("}"), "[4]" },
-            };
+        protected static readonly Dictionary<string, string> RegexSpecialCharactersReplacements = new()
+        {
+            { Regex.Escape("("), "[1]" },
+            { Regex.Escape(")"), "[2]" },
+            { Regex.Escape("{"), "[3]" },
+            { Regex.Escape("}"), "[4]" },
+        };
 
         // Regex Replacement values
         protected const string RegexText = "Valid \"version\": \"garbage\" Valid";
-        protected static readonly Dictionary<string, string> RegexReplacements = 
-            new Dictionary<string, string>()
-            {
-                { "\"version\": \".*\"", "\"version\": \"0.0.0-development\""},
-            };
+        protected static readonly Dictionary<string, string> RegexReplacements = new()
+        {
+            { "\"version\": \".*\"", "\"version\": \"0.0.0-development\""},
+        };
         protected const string RegexResults = "Valid \"version\": \"0.0.0-development\" Valid";
 
         #endregion Test Values
@@ -59,25 +56,24 @@ namespace AlchemicalFlux.Utilities.Helpers.Tests
         // Test names
         protected const string RegexReplacementsTestName = "RegexReplacements_ReturnModifiedString";
 
-        protected static readonly Dictionary<string, TestCaseData> RegexReplacementScenariosData =
-            new Dictionary<string, TestCaseData>()
+        protected static readonly Dictionary<string, TestCaseData> RegexReplacementScenariosData = new()
+        {
             {
-                {
-                    EscapeCharacterReplacementTestName,
-                    new(new RegexStringManipulator(),
-                        EscapeCharactersText, RegexCharactersReplacements, EscapeCharactersResult)
-                },
-                {
-                    SpecialCharacterReplacementsTestName,
-                    new(new RegexStringManipulator(),
-                        SpecialCharactersText, RegexSpecialCharactersReplacements, SpecialCharactersResult)
-                },
-                {
-                    RegexReplacementsTestName,
-                    new(new RegexStringManipulator(),
-                        RegexText, RegexReplacements, RegexResults)
-                },
-            };
+                EscapeCharacterReplacementTestName,
+                new(new RegexStringManipulator(),
+                    EscapeCharactersText, RegexCharactersReplacements, EscapeCharactersResult)
+            },
+            {
+                SpecialCharacterReplacementsTestName,
+                new(new RegexStringManipulator(),
+                    SpecialCharactersText, RegexSpecialCharactersReplacements, SpecialCharactersResult)
+            },
+            {
+                RegexReplacementsTestName,
+                new(new RegexStringManipulator(),
+                    RegexText, RegexReplacements, RegexResults)
+            },
+        };
 
         #endregion Test Scenarios
 

--- a/Tests/Editor/Scripts/PackageGeneration/PackageEditorUITests.cs
+++ b/Tests/Editor/Scripts/PackageGeneration/PackageEditorUITests.cs
@@ -5,7 +5,7 @@
   Copyright:      ©2023 AlchemicalFlux. All rights reserved.
 
   Last commit by: alchemicalflux 
-  Last commit at: 2024-02-15 08:41:19 
+  Last commit at: 2024-11-29 20:46:10 
 ------------------------------------------------------------------------------*/
 using NUnit.Framework;
 using UnityEngine.UIElements;
@@ -83,8 +83,8 @@ namespace AlchemicalFlux.Utilities.PackageGeneration.Tests
             // Arrange
             var expectedFoldersToRemove = new List<string>
             {
-                "*" + PackageConstants.DocumentationFolderName + "*",
-                "*" + PackageConstants.SamplesFolderName + "*",
+                $"*{PackageConstants.DocumentationFolderName}*",
+                $"*{PackageConstants.SamplesFolderName}*",
             };
 
             // Act

--- a/Tests/Runtime/Resources/Helpers/NullCheck/NullCheck.prefab
+++ b/Tests/Runtime/Resources/Helpers/NullCheck/NullCheck.prefab
@@ -44,3 +44,4 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 10e3ab442f55c7b4282eeedb88ec34fe, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  _object: {fileID: 0}

--- a/Tests/Runtime/Scripts/Helpers/NullCheck/NullCheckTestSO.cs
+++ b/Tests/Runtime/Scripts/Helpers/NullCheck/NullCheckTestSO.cs
@@ -7,7 +7,7 @@
   Copyright:      ©2024 AlchemicalFlux. All rights reserved.
 
   Last commit by: alchemicalflux 
-  Last commit at: 2024-02-15 08:00:02 
+  Last commit at: 2024-11-29 20:48:48 
 ------------------------------------------------------------------------------*/
 using UnityEngine;
 
@@ -46,23 +46,23 @@ namespace AlchemicalFlux.Utilities.Helpers.Tests
         /// <returns>Reference to a GameObject.</returns>
         public GameObject Get(NullCheckTestType type)
         {
-            switch (type)
+            return type switch
             {
-                case NullCheckTestType.EmptyObject: return EmptyObjectTest;
-                case NullCheckTestType.EmptyScript: return EmptyScriptTest;
-                case NullCheckTestType.ValueFields: return ValueFieldsTest;
-                case NullCheckTestType.NullCheck: return NullCheckTest;
-                case NullCheckTestType.PrefabNullCheck: return PrefabNullCheckTest;
-                case NullCheckTestType.LinkedNullCheck: return LinkedNullCheckTest;
-                case NullCheckTestType.LinkedPrefabNullCheck: return LinkedPrefabNullCheckTest;
-                case NullCheckTestType.ChildNullCheck: return ChildNullCheckTest;
-                case NullCheckTestType.ChildPrefabNullCheck: return ChildPrefabNullCheckTest;
-                case NullCheckTestType.LinkedChildNullCheck: return LinkedChildNullCheckTest;
-                case NullCheckTestType.LinkedChildPrefabNullCheck: return LinkedChildPrefabNullCheckTest;
-                case NullCheckTestType.MultiNullCheck: return MultiNullCheckTest;
-                case NullCheckTestType.LinkedMultiNullCheck: return LinkedMultiNullCheckTest;
-            }
-            return null;
+                NullCheckTestType.EmptyObject => EmptyObjectTest,
+                NullCheckTestType.EmptyScript => EmptyScriptTest,
+                NullCheckTestType.ValueFields => ValueFieldsTest,
+                NullCheckTestType.NullCheck => NullCheckTest,
+                NullCheckTestType.PrefabNullCheck => PrefabNullCheckTest,
+                NullCheckTestType.LinkedNullCheck => LinkedNullCheckTest,
+                NullCheckTestType.LinkedPrefabNullCheck => LinkedPrefabNullCheckTest,
+                NullCheckTestType.ChildNullCheck => ChildNullCheckTest,
+                NullCheckTestType.ChildPrefabNullCheck => ChildPrefabNullCheckTest,
+                NullCheckTestType.LinkedChildNullCheck => LinkedChildNullCheckTest,
+                NullCheckTestType.LinkedChildPrefabNullCheck => LinkedChildPrefabNullCheckTest,
+                NullCheckTestType.MultiNullCheck => MultiNullCheckTest,
+                NullCheckTestType.LinkedMultiNullCheck => LinkedMultiNullCheckTest,
+                _ => null,
+            };
         }
 
         #endregion Methods

--- a/Tests/Runtime/Scripts/Helpers/NullCheck/NullCheckTests.cs
+++ b/Tests/Runtime/Scripts/Helpers/NullCheck/NullCheckTests.cs
@@ -5,7 +5,7 @@
   Copyright:      ©2024 AlchemicalFlux. All rights reserved.
 
   Last commit by: alchemicalflux 
-  Last commit at: 2024-11-29 20:48:48 
+  Last commit at: 2024-11-29 20:56:00 
 ------------------------------------------------------------------------------*/
 using NUnit.Framework;
 using System.Collections.Generic;
@@ -38,55 +38,55 @@ namespace AlchemicalFlux.Utilities.Helpers.Tests
         {
             {
                 _emptyGameObjectTestName,
-                new TestCaseData(NullCheckTestType.EmptyObject, 0)
+                new(NullCheckTestType.EmptyObject, 0)
             },
             {
                 _emptyScriptTestName,
-                new TestCaseData(NullCheckTestType.EmptyScript, 0)
+                new(NullCheckTestType.EmptyScript, 0)
             },
             {
                 _valueFieldsTestName,
-                new TestCaseData(NullCheckTestType.ValueFields, 12)
+                new(NullCheckTestType.ValueFields, 12)
             },
             {
                 _nullCheckTestName,
-                new TestCaseData(NullCheckTestType.NullCheck, 1)
+                new(NullCheckTestType.NullCheck, 1)
             },
             {
                 _prefabNullCheckTestName,
-                new TestCaseData(NullCheckTestType.PrefabNullCheck, 1)
+                new(NullCheckTestType.PrefabNullCheck, 1)
             },
             {
                 _linkedNullCheckTestName,
-                new TestCaseData(NullCheckTestType.LinkedNullCheck, 0)
+                new(NullCheckTestType.LinkedNullCheck, 0)
             },
             {
                 _linkedPrefabNullCheckTestName,
-                new TestCaseData(NullCheckTestType.LinkedPrefabNullCheck, 0)
+                new(NullCheckTestType.LinkedPrefabNullCheck, 0)
             },
             {
                 _multiNullCheckTestName,
-                new TestCaseData(NullCheckTestType.MultiNullCheck, 8)
+                new(NullCheckTestType.MultiNullCheck, 8)
             },
             {
                 _linkedMultiNullCheckTestName,
-                new TestCaseData(NullCheckTestType.LinkedMultiNullCheck, 0)
+                new(NullCheckTestType.LinkedMultiNullCheck, 0)
             },
             {
                 _childNullCheckTestName,
-                new TestCaseData(NullCheckTestType.ChildNullCheck, 1)
+                new(NullCheckTestType.ChildNullCheck, 1)
             },
             {
                 _childPrefabNullCheckTestName,
-                new TestCaseData(NullCheckTestType.ChildPrefabNullCheck, 1)
+                new(NullCheckTestType.ChildPrefabNullCheck, 1)
             },
             {
                 _linkedChildNullCheckTestName,
-                new TestCaseData(NullCheckTestType.LinkedChildNullCheck, 0)
+                new(NullCheckTestType.LinkedChildNullCheck, 0)
             },
             {
                 _linkedChildPrefabNullCheckTestName,
-                new TestCaseData(NullCheckTestType.LinkedChildPrefabNullCheck, 0)
+                new(NullCheckTestType.LinkedChildPrefabNullCheck, 0)
             },
         };
 

--- a/Tests/Runtime/Scripts/Helpers/NullCheck/NullCheckTests.cs
+++ b/Tests/Runtime/Scripts/Helpers/NullCheck/NullCheckTests.cs
@@ -5,7 +5,7 @@
   Copyright:      ©2024 AlchemicalFlux. All rights reserved.
 
   Last commit by: alchemicalflux 
-  Last commit at: 2024-02-20 10:32:48 
+  Last commit at: 2024-11-29 20:48:48 
 ------------------------------------------------------------------------------*/
 using NUnit.Framework;
 using System.Collections.Generic;
@@ -34,62 +34,61 @@ namespace AlchemicalFlux.Utilities.Helpers.Tests
         private const string _linkedChildNullCheckTestName = "LinkedChildNullCheck_ReturnsNoErrors";
         private const string _linkedChildPrefabNullCheckTestName = "LinkedChildPrefabNullCheck_ReturnsNoErrors";
 
-        private static readonly Dictionary<string, TestCaseData> _instantiatedScenarioData =
-            new Dictionary<string, TestCaseData>()
+        private static readonly Dictionary<string, TestCaseData> _instantiatedScenarioData = new()
+        {
             {
-                {
-                    _emptyGameObjectTestName,
-                    new TestCaseData(NullCheckTestType.EmptyObject, 0)
-                },
-                {
-                    _emptyScriptTestName,
-                    new TestCaseData(NullCheckTestType.EmptyScript, 0)
-                },
-                {
-                    _valueFieldsTestName,
-                    new TestCaseData(NullCheckTestType.ValueFields, 12)
-                },
-                {
-                    _nullCheckTestName,
-                    new TestCaseData(NullCheckTestType.NullCheck, 1)
-                },
-                {
-                    _prefabNullCheckTestName,
-                    new TestCaseData(NullCheckTestType.PrefabNullCheck, 1)
-                },
-                {
-                    _linkedNullCheckTestName,
-                    new TestCaseData(NullCheckTestType.LinkedNullCheck, 0)
-                },
-                {
-                    _linkedPrefabNullCheckTestName,
-                    new TestCaseData(NullCheckTestType.LinkedPrefabNullCheck, 0)
-                },
-                {
-                    _multiNullCheckTestName,
-                    new TestCaseData(NullCheckTestType.MultiNullCheck, 8)
-                },
-                {
-                    _linkedMultiNullCheckTestName,
-                    new TestCaseData(NullCheckTestType.LinkedMultiNullCheck, 0)
-                },
-                {
-                    _childNullCheckTestName,
-                    new TestCaseData(NullCheckTestType.ChildNullCheck, 1)
-                },
-                {
-                    _childPrefabNullCheckTestName,
-                    new TestCaseData(NullCheckTestType.ChildPrefabNullCheck, 1)
-                },
-                {
-                    _linkedChildNullCheckTestName,
-                    new TestCaseData(NullCheckTestType.LinkedChildNullCheck, 0)
-                },
-                {
-                    _linkedChildPrefabNullCheckTestName,
-                    new TestCaseData(NullCheckTestType.LinkedChildPrefabNullCheck, 0)
-                },
-            };
+                _emptyGameObjectTestName,
+                new TestCaseData(NullCheckTestType.EmptyObject, 0)
+            },
+            {
+                _emptyScriptTestName,
+                new TestCaseData(NullCheckTestType.EmptyScript, 0)
+            },
+            {
+                _valueFieldsTestName,
+                new TestCaseData(NullCheckTestType.ValueFields, 12)
+            },
+            {
+                _nullCheckTestName,
+                new TestCaseData(NullCheckTestType.NullCheck, 1)
+            },
+            {
+                _prefabNullCheckTestName,
+                new TestCaseData(NullCheckTestType.PrefabNullCheck, 1)
+            },
+            {
+                _linkedNullCheckTestName,
+                new TestCaseData(NullCheckTestType.LinkedNullCheck, 0)
+            },
+            {
+                _linkedPrefabNullCheckTestName,
+                new TestCaseData(NullCheckTestType.LinkedPrefabNullCheck, 0)
+            },
+            {
+                _multiNullCheckTestName,
+                new TestCaseData(NullCheckTestType.MultiNullCheck, 8)
+            },
+            {
+                _linkedMultiNullCheckTestName,
+                new TestCaseData(NullCheckTestType.LinkedMultiNullCheck, 0)
+            },
+            {
+                _childNullCheckTestName,
+                new TestCaseData(NullCheckTestType.ChildNullCheck, 1)
+            },
+            {
+                _childPrefabNullCheckTestName,
+                new TestCaseData(NullCheckTestType.ChildPrefabNullCheck, 1)
+            },
+            {
+                _linkedChildNullCheckTestName,
+                new TestCaseData(NullCheckTestType.LinkedChildNullCheck, 0)
+            },
+            {
+                _linkedChildPrefabNullCheckTestName,
+                new TestCaseData(NullCheckTestType.LinkedChildPrefabNullCheck, 0)
+            },
+        };
 
         #endregion Test Scenerios
 
@@ -97,7 +96,7 @@ namespace AlchemicalFlux.Utilities.Helpers.Tests
 
         private static IEnumerable<TestCaseData> InstantiateGameObjectTests()
         {
-            foreach (var scenario in _instantiatedScenarioData)
+            foreach(var scenario in _instantiatedScenarioData)
             {
                 yield return scenario.Value.SetName(scenario.Key);
             }

--- a/Tests/Runtime/Scripts/Helpers/NullCheck/NullCheckTests_EditorOnly.cs
+++ b/Tests/Runtime/Scripts/Helpers/NullCheck/NullCheckTests_EditorOnly.cs
@@ -5,7 +5,7 @@
   Copyright:      ©2024 AlchemicalFlux. All rights reserved.
 
   Last commit by: alchemicalflux 
-  Last commit at: 2024-02-20 10:32:48 
+  Last commit at: 2024-11-29 20:48:48 
 ------------------------------------------------------------------------------*/
 #if UNITY_EDITOR
 
@@ -36,62 +36,61 @@ namespace AlchemicalFlux.Utilities.Helpers.Tests
         private const string _linkedChildPrefabNullCheckPrefabTestName = "LinkedChildPrefabNullCheck_ReturnsNoErrors";
 
         // Prefab Scenerio Tests
-        private static readonly Dictionary<string, TestCaseData> _prefabScenarioData =
-             new Dictionary<string, TestCaseData>()
-             {
-                {
-                    _emptyGameObjectPrefabTestName,
-                    new TestCaseData(NullCheckTestType.EmptyObject, 0)
-                },
-                {
-                    _emptyScriptPrefabTestName,
-                    new TestCaseData(NullCheckTestType.EmptyScript, 0)
-                },
-                {
-                    _valueFieldsPrefabTestName,
-                    new TestCaseData(NullCheckTestType.ValueFields, 12)
-                },
-                {
-                    _nullCheckPrefabTestName,
-                    new TestCaseData(NullCheckTestType.NullCheck, 1)
-                },
-                {
-                    _prefabNullCheckPrefabTestName,
-                    new TestCaseData(NullCheckTestType.PrefabNullCheck, 0)
-                },
-                {
-                    _linkedNullCheckPrefabTestName,
-                    new TestCaseData(NullCheckTestType.LinkedNullCheck, 0)
-                },
-                {
-                    _linkedPrefabNullCheckPrefabTestName,
-                    new TestCaseData(NullCheckTestType.LinkedPrefabNullCheck, 0)
-                },
-                {
-                    _multiNullCheckPrefabTestName,
-                    new TestCaseData(NullCheckTestType.MultiNullCheck, 4)
-                },
-                {
-                    _linkedMultiNullCheckPrefabTestName,
-                    new TestCaseData(NullCheckTestType.LinkedMultiNullCheck, 0)
-                },
-                {
-                    _childNullCheckPrefabTestName,
-                    new TestCaseData(NullCheckTestType.ChildNullCheck, 1)
-                },
-                {
-                    _childPrefabNullCheckPrefabTestName,
-                    new TestCaseData(NullCheckTestType.ChildPrefabNullCheck, 0)
-                },
-                {
-                    _linkedChildNullCheckPrefabTestName,
-                    new TestCaseData(NullCheckTestType.LinkedChildNullCheck, 0)
-                },
-                {
-                    _linkedChildPrefabNullCheckPrefabTestName,
-                    new TestCaseData(NullCheckTestType.LinkedChildPrefabNullCheck, 0)
-                },
-             };
+        private static readonly Dictionary<string, TestCaseData> _prefabScenarioData = new()
+        {
+            {
+                _emptyGameObjectPrefabTestName,
+                new TestCaseData(NullCheckTestType.EmptyObject, 0)
+            },
+            {
+                _emptyScriptPrefabTestName,
+                new TestCaseData(NullCheckTestType.EmptyScript, 0)
+            },
+            {
+                _valueFieldsPrefabTestName,
+                new TestCaseData(NullCheckTestType.ValueFields, 12)
+            },
+            {
+                _nullCheckPrefabTestName,
+                new TestCaseData(NullCheckTestType.NullCheck, 1)
+            },
+            {
+                _prefabNullCheckPrefabTestName,
+                new TestCaseData(NullCheckTestType.PrefabNullCheck, 0)
+            },
+            {
+                _linkedNullCheckPrefabTestName,
+                new TestCaseData(NullCheckTestType.LinkedNullCheck, 0)
+            },
+            {
+                _linkedPrefabNullCheckPrefabTestName,
+                new TestCaseData(NullCheckTestType.LinkedPrefabNullCheck, 0)
+            },
+            {
+                _multiNullCheckPrefabTestName,
+                new TestCaseData(NullCheckTestType.MultiNullCheck, 4)
+            },
+            {
+                _linkedMultiNullCheckPrefabTestName,
+                new TestCaseData(NullCheckTestType.LinkedMultiNullCheck, 0)
+            },
+            {
+                _childNullCheckPrefabTestName,
+                new TestCaseData(NullCheckTestType.ChildNullCheck, 1)
+            },
+            {
+                _childPrefabNullCheckPrefabTestName,
+                new TestCaseData(NullCheckTestType.ChildPrefabNullCheck, 0)
+            },
+            {
+                _linkedChildNullCheckPrefabTestName,
+                new TestCaseData(NullCheckTestType.LinkedChildNullCheck, 0)
+            },
+            {
+                _linkedChildPrefabNullCheckPrefabTestName,
+                new TestCaseData(NullCheckTestType.LinkedChildPrefabNullCheck, 0)
+            },
+        };
 
         #endregion Test Scenerios
 
@@ -99,7 +98,7 @@ namespace AlchemicalFlux.Utilities.Helpers.Tests
 
         private static IEnumerable<TestCaseData> PrefabGameObjectTests()
         {
-            foreach (var scenario in _prefabScenarioData)
+            foreach(var scenario in _prefabScenarioData)
             {
                 yield return scenario.Value.SetName(scenario.Key);
             }

--- a/Tests/Runtime/Scripts/Helpers/NullCheck/NullCheckTests_EditorOnly.cs
+++ b/Tests/Runtime/Scripts/Helpers/NullCheck/NullCheckTests_EditorOnly.cs
@@ -5,7 +5,7 @@
   Copyright:      ©2024 AlchemicalFlux. All rights reserved.
 
   Last commit by: alchemicalflux 
-  Last commit at: 2024-11-29 20:48:48 
+  Last commit at: 2024-11-29 20:56:00 
 ------------------------------------------------------------------------------*/
 #if UNITY_EDITOR
 
@@ -40,55 +40,55 @@ namespace AlchemicalFlux.Utilities.Helpers.Tests
         {
             {
                 _emptyGameObjectPrefabTestName,
-                new TestCaseData(NullCheckTestType.EmptyObject, 0)
+                new(NullCheckTestType.EmptyObject, 0)
             },
             {
                 _emptyScriptPrefabTestName,
-                new TestCaseData(NullCheckTestType.EmptyScript, 0)
+                new(NullCheckTestType.EmptyScript, 0)
             },
             {
                 _valueFieldsPrefabTestName,
-                new TestCaseData(NullCheckTestType.ValueFields, 12)
+                new(NullCheckTestType.ValueFields, 12)
             },
             {
                 _nullCheckPrefabTestName,
-                new TestCaseData(NullCheckTestType.NullCheck, 1)
+                new(NullCheckTestType.NullCheck, 1)
             },
             {
                 _prefabNullCheckPrefabTestName,
-                new TestCaseData(NullCheckTestType.PrefabNullCheck, 0)
+                new(NullCheckTestType.PrefabNullCheck, 0)
             },
             {
                 _linkedNullCheckPrefabTestName,
-                new TestCaseData(NullCheckTestType.LinkedNullCheck, 0)
+                new(NullCheckTestType.LinkedNullCheck, 0)
             },
             {
                 _linkedPrefabNullCheckPrefabTestName,
-                new TestCaseData(NullCheckTestType.LinkedPrefabNullCheck, 0)
+                new(NullCheckTestType.LinkedPrefabNullCheck, 0)
             },
             {
                 _multiNullCheckPrefabTestName,
-                new TestCaseData(NullCheckTestType.MultiNullCheck, 4)
+                new(NullCheckTestType.MultiNullCheck, 4)
             },
             {
                 _linkedMultiNullCheckPrefabTestName,
-                new TestCaseData(NullCheckTestType.LinkedMultiNullCheck, 0)
+                new(NullCheckTestType.LinkedMultiNullCheck, 0)
             },
             {
                 _childNullCheckPrefabTestName,
-                new TestCaseData(NullCheckTestType.ChildNullCheck, 1)
+                new(NullCheckTestType.ChildNullCheck, 1)
             },
             {
                 _childPrefabNullCheckPrefabTestName,
-                new TestCaseData(NullCheckTestType.ChildPrefabNullCheck, 0)
+                new(NullCheckTestType.ChildPrefabNullCheck, 0)
             },
             {
                 _linkedChildNullCheckPrefabTestName,
-                new TestCaseData(NullCheckTestType.LinkedChildNullCheck, 0)
+                new(NullCheckTestType.LinkedChildNullCheck, 0)
             },
             {
                 _linkedChildPrefabNullCheckPrefabTestName,
-                new TestCaseData(NullCheckTestType.LinkedChildPrefabNullCheck, 0)
+                new(NullCheckTestType.LinkedChildPrefabNullCheck, 0)
             },
         };
 

--- a/Tests/Runtime/Scripts/Helpers/NullCheck/NullCheckTests_Shared.cs
+++ b/Tests/Runtime/Scripts/Helpers/NullCheck/NullCheckTests_Shared.cs
@@ -5,10 +5,9 @@
   Copyright:      ©2024 AlchemicalFlux. All rights reserved.
 
   Last commit by: alchemicalflux 
-  Last commit at: 2024-02-20 10:32:48 
+  Last commit at: 2024-11-29 20:48:48 
 ------------------------------------------------------------------------------*/
 using NUnit.Framework;
-using System.Collections.Generic;
 using UnityEngine;
 
 namespace AlchemicalFlux.Utilities.Helpers.Tests
@@ -29,6 +28,12 @@ namespace AlchemicalFlux.Utilities.Helpers.Tests
         {
             // Arrange
             _testObjects = Resources.Load<NullCheckTestSO>("Helpers/NullCheck/NullCheckTestSO");
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            Resources.UnloadAsset(_testObjects);
         }
 
         #endregion Methods


### PR DESCRIPTION
- Apply Intellisense suggestions, such as reducing constructor statements, adding readonly, and other simplifications.
- Remove excess spaces after conditional checks and loops.
- Switch to string interpolation.
- Implement stack-based object heirarchy path string generation.